### PR TITLE
fix: 修复 Jupyter 主题样式污染问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.2.5
+
+_2025-05-04_
+
+### Bug fixes
+
+- [#94](https://github.com/Z-J-wang/render-jupyter-notebook-vue/issues/94) 修复：Jupyter Theme 样式污染问题
+
 ## 2.2.4
 
 _2024-12-10_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "render-jupyter-notebook-vue",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "license": "MIT",
   "homepage": "https://z-j-wang.github.io/render-jupyter-notebook-vue/#/",
   "repository": "https://github.com/Z-J-wang/render-jupyter-notebook-vue",

--- a/src/assets/css/jupyterlab/index.css
+++ b/src/assets/css/jupyterlab/index.css
@@ -1,3 +1,4 @@
+@import url('./ligth.theme.css');
 @import url('./lumino.widgets.widget.css');
 @import url('./materialcolors.css');
 @import url('./rendermine.base.css');

--- a/src/assets/css/jupyterlab/ligth.theme.css
+++ b/src/assets/css/jupyterlab/ligth.theme.css
@@ -1,0 +1,14 @@
+/* 此文件重写了@jupyterlab/theme-light-extension/style/theme.css  中的部分样式
+用于解决 tt、code、kbd、samp、pre 样式污染问题 */
+
+@import '@jupyterlab/theme-light-extension/style/variables.css';
+
+.lm-Widget tt,
+.lm-Widget code,
+.lm-Widget kbd,
+.lm-Widget samp,
+.lm-Widget pre {
+  font-family: var(--jp-code-font-family);
+  font-size: var(--jp-code-font-size);
+  line-height: var(--jp-code-line-height);
+}

--- a/src/utils/notebook/index.js
+++ b/src/utils/notebook/index.js
@@ -1,4 +1,3 @@
-import '@jupyterlab/theme-light-extension/style/theme.css';
 import '../../assets/css/jupyterlab/index.css';
 import { createCodemirror } from './codemirror';
 import { defaultSanitizer } from './sanitizer';


### PR DESCRIPTION
- 更新版本号至 2.2.5
- 新增 ligth.theme.css 文件，重写部分 Jupyter 主题样式
- 解决 tt、code、kbd、samp、pre 样式污染问题
- 移除不必要的主题引用，优化代码结构